### PR TITLE
/tmp should be empty

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 ADD target/dist/c-bastion-* /tmp/c-bastion/
 RUN ls /tmp/c-bastion
 RUN cd /tmp/c-bastion && pip install .
+RUN rm -rf /tmp/c-bastion
 RUN echo 'export PS1="${debian_chroot:+($debian_chroot)}\u@\H:\w\$ "' >> /etc/profile
 EXPOSE 22 8080
 

--- a/src/cmdlinetest/test.t
+++ b/src/cmdlinetest/test.t
@@ -110,6 +110,18 @@
   > "ls /data/home"
   integrationtestuser
 
+# ensure that /tmp only contains the bottle lock
+
+  $ ssh localhost \
+  > -p $JUMP_SSH_PORT \
+  > -l integrationtestuser \
+  > -i integration_key \
+  > -o StrictHostKeyChecking=no \
+  > -o PasswordAuthentication=no \
+  > -q -T \
+  > "ls /tmp"
+  bottle*lock (glob)
+
 # Delete the user again with cbas
 
   $ cbas -u integrationtestuser -p testing \


### PR DESCRIPTION
On a freshly started c-bastion server `/tmp` contains internal files. This could be a security risk.

```
schlomo@cbastionx.y.z:/tmp$ls -l
total 4
-rw------- 1 root root    0 Mar 18 10:26 bottle.69uoxP.lock
drwxr-xr-x 4 root root 4096 Mar 15 15:45 c-bastion
```

Even if not it would be nicer to leave /tmp empty and have it only for the user stuff, if at all. 
