### PR TITLE
remove client secret from cbas calls, it has been removed upstream

### DIFF
--- a/src/cmdlinetest/test.t
+++ b/src/cmdlinetest/test.t
@@ -90,7 +90,6 @@
   $ cbas -u integrationtestuser -p testing \
   > -k integration_key.pub \
   > -h localhost:$JUMP_HTTP_PORT \
-  > -s client_secret \
   > -a http://localhost:$AUTH_PORT/oauth/token \
   > upload
   Will now attempt to obtain an JWT...
@@ -116,7 +115,6 @@
   $ cbas -u integrationtestuser -p testing \
   > -k integration_key.pub \
   > -h localhost:$JUMP_HTTP_PORT \
-  > -s client_secret \
   > -a http://localhost:$AUTH_PORT/oauth/token \
   > delete
   Will now attempt to obtain an JWT...


### PR DESCRIPTION
The clien_secret has been removed from cbas, so remove it from the tests here too.
