### PR TITLE
nowadays one needs to install setuptools too

### DIFF
--- a/src/cmdlinetest/test.t
+++ b/src/cmdlinetest/test.t
@@ -24,7 +24,7 @@
 
 #  Update pip, just in cases.
 
-  $ pip install -U pip > /dev/null 2>&1
+  $ pip install -U pip setuptools > /dev/null 2>&1
   $ which pip
   */test.t/venv/bin/pip (glob)
 


### PR DESCRIPTION
It is good practice to update setuptools too, in fact not doing this will mean
cbas can't be installed (because it's deps can't be).
