### PR TITLE
Add blank to shell prompt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 ADD target/dist/c-bastion-* /tmp/c-bastion/
 RUN ls /tmp/c-bastion
 RUN cd /tmp/c-bastion && pip install .
-RUN echo 'export PS1="${debian_chroot:+($debian_chroot)}\u@\H:\w\$"' >> /etc/profile
+RUN echo 'export PS1="${debian_chroot:+($debian_chroot)}\u@\H:\w\$ "' >> /etc/profile
 EXPOSE 22 8080
 
 CMD ["/usr/bin/supervisord"]


### PR DESCRIPTION
The shell prompt lacks the blank at the end:

```
schlomo@cbastionx.y.z:/tmp$
schlomo@cbastionx.y.z:/tmp$date
Fri Mar 18 10:27:15 UTC 2016
schlomo@cbastionx.y.z:/tmp$
schlomo@cbastionx.y.z:/tmp$
```

This makes it difficult to see where the prompt ends and where my input starts
