### PR TITLE
Ssh personal environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
-.idea
+/.idea
 target
-venv
-*.iml
+/venv
+/*.iml
 .coverage
 *.pyc
+*.t.err

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,26 +2,42 @@ FROM ubuntu:trusty
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN echo 'deb mirror://mirrors.ubuntu.com/mirrors.txt trusty main restricted universe multiverse' > /etc/apt/sources.list; \
-echo 'deb mirror://mirrors.ubuntu.com/mirrors.txt trusty-updates main restricted universe multiverse' >> /etc/apt/sources.list; \
-echo 'deb mirror://mirrors.ubuntu.com/mirrors.txt trusty-security main restricted universe multiverse' >> /etc/apt/sources.list; \
-echo 'deb-src mirror://mirrors.ubuntu.com/mirrors.txt trusty main restricted universe multiverse' >> /etc/apt/sources.list; \
-echo 'deb-src mirror://mirrors.ubuntu.com/mirrors.txt trusty-updates main restricted universe multiverse' >> /etc/apt/sources.list; \
-echo 'deb-src mirror://mirrors.ubuntu.com/mirrors.txt trusty-security main restricted universe multiverse' >> /etc/apt/sources.list;
+RUN apt-get -q update && apt-get -q -y install --no-install-recommends \
+    openssh-client \
+    openssh-server \
+    python-pip \
+    python-virtualenv \
+    screen \
+    supervisor \
+    tmux \
+    vim-nox \
+    zsh
 
-RUN apt-get update && apt-get install -y openssh-server supervisor python-pip vim-gtk
-
-RUN locale-gen "en_US.UTF-8" && dpkg-reconfigure locales
+RUN locale-gen en_US.UTF-8 de_DE.UTF-8 && update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
 
 
-RUN mkdir -p /var/run/sshd /var/log/supervisor
-RUN touch /var/log/cron.log
-COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-ADD target/dist/c-bastion-* /tmp/c-bastion/
-RUN ls /tmp/c-bastion
-RUN cd /tmp/c-bastion && pip install .
-RUN rm -rf /tmp/c-bastion
-RUN echo 'export PS1="${debian_chroot:+($debian_chroot)}\u@\H:\w\$ "' >> /etc/profile
+RUN mkdir -p /var/run/sshd /var/log/supervisor && \
+    touch /var/log/cron.log && \
+    rm -f /etc/skel/.bashrc /root/.bashrc
+
+RUN echo "dash dash/sh boolean false" | debconf-set-selections && \
+    dpkg-reconfigure dash
+
+COPY configs/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+COPY configs/profile.sh /etc/profile.d/zzz_c-bastion.sh
+
+COPY configs/sshrc.sh /etc/ssh/sshrc
+RUN echo '    SendEnv USERHOME_DATA' >> /etc/ssh/ssh_config && \
+    echo 'AcceptEnv USERHOME_DATA' >> /etc/ssh/sshd_config
+
+COPY configs/screenrc /etc/screenrc
+COPY target/dist/c-bastion-* /tmp/c-bastion/
+RUN ls /tmp/c-bastion && \
+    cd /tmp/c-bastion && \
+    pip install . && \
+    rm -rf /tmp/c-bastion
+
 EXPOSE 22 8080
 
 CMD ["/usr/bin/supervisord"]

--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,7 @@ Where ``developer`` is your local machine (desktop, laptop, etc..) ``auth
 server`` is the auth-server and ``jump host`` is the jump host. ``cbas`` takes
 care of obtaining the token and uploading the ssh-key.
 
+
 Architecture
 ============
 

--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,26 @@ Where ``developer`` is your local machine (desktop, laptop, etc..) ``auth
 server`` is the auth-server and ``jump host`` is the jump host. ``cbas`` takes
 care of obtaining the token and uploading the ssh-key.
 
+Features
+========
+
+The bastion host is a slim Ubuntu and contains the following extra features:
+
+* `vim-nox`_
+* `screen`_ and `tmux`_
+* `zsh`_
+* python with `pip`_ and `virtualenv`_
+* Import `your Personal Environment via SSH`__
+
+.. __: http://blog.schlomo.schapiro.org/2014/02/ssh-with-personal-environment.html
+
+.. _vim-nox: http://packages.ubuntu.com/trusty/vim-nox
+.. _screen: http://packages.ubuntu.com/trusty/screen
+.. _tmux: http://packages.ubuntu.com/trusty/tmux
+.. _zsh: http://packages.ubuntu.com/trusty/zsh
+.. _pip: http://packages.ubuntu.com/trusty/python-pip
+.. _python-virtualenv: http://packages.ubuntu.com/trusty/python-virtualenv
+
 
 Architecture
 ============

--- a/README.rst
+++ b/README.rst
@@ -136,7 +136,7 @@ You could also check the current version:
 Development
 ===========
 
-The project uses PyBuilder and GNU-Make as build and test tool. GNU-Make is
+The project is written in Python 2.7 and uses PyBuilder and GNU-Make as build and test tool. GNU-Make is
 used in addition to PyBuilder since this project is basically some Python code
 and some Docker logic so more than *just* PyBuilder was needed. The
 build-system is cobbled together and somewhat flakey, so a few tips and tricks

--- a/configs/profile.sh
+++ b/configs/profile.sh
@@ -1,0 +1,17 @@
+PS1="\u@\H:\w\$ "
+
+alias ll='ls -alF'
+alias la='ls -A'
+alias l='ls -CF'
+
+if [ -f ~/.bash_aliases ]; then
+    . ~/.bash_aliases
+fi
+
+if ! shopt -oq posix; then
+  if [ -f /usr/share/bash-completion/bash_completion ]; then
+    . /usr/share/bash-completion/bash_completion
+  elif [ -f /etc/bash_completion ]; then
+    . /etc/bash_completion
+  fi
+fi

--- a/configs/screenrc
+++ b/configs/screenrc
@@ -1,0 +1,29 @@
+# this is the global screenrc file. Handle with care.
+
+termcapinfo xterm* G0:is=\E[?3;4l\E>
+termcapinfo linux me=\E[m:AX
+defscrollback 10000
+
+# An alternative hardstatus to display a bar at the bottom listing the
+# windownames and highlighting the current windowname in blue. (This is only
+# enabled if there is no hardstatus setting for your terminal)
+hardstatus on
+hardstatus alwayslastline
+hardstatus string "%{.bW}%-w%{.rW}%n %t%{-}%+w %=load:%{..R} %l%{..G} %H %{..Y} %d.%m. %c "
+
+# recognize shells
+shelltitle "$ |# |bash"
+shell -bash
+
+# reconnecting to a running screen with SSH agent requires a persistent name for the auth socket.
+# use some script like /etc/ssh/sshrc to symlink the actualy socket to this persistent name
+setenv SSH_AUTH_SOCK ${HOME}/.ssh/ssh_auth_sock
+
+# don't show the startup screen
+startup_message off
+
+# freeze sux
+bind s
+
+# this properly closes e.g. vim and restores the shell history
+altscreen on

--- a/configs/sshrc.sh
+++ b/configs/sshrc.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# xauth handling, code adapted from sshd(8)
+if type -p xauth >/dev/null && read proto cookie && [[ "$DISPLAY" ]]; then
+        if [[ "${DISPLAY:0:10}" = 'localhost:' ]] ; then
+                # X11UseLocalhost=yes
+                #echo add unix:"${DISPLAY:11}" $proto $cookie   #### egrehm changed to :10 because seems to be broken on rhel6 and clones
+                echo add unix:"${DISPLAY:10}" $proto $cookie
+        else
+                # X11UseLocalhost=no
+                echo add "$DISPLAY" $proto $cookie
+        fi | xauth -q -
+fi
+
+# make ssh agent accessible through predictable socket path
+# (required to reconnect to screen sessions and keeping ssh agent working)
+if [[ "$SSH_AUTH_SOCK" && "$SSH_AUTH_SOCK" != ~/.ssh/ssh_auth_sock ]] ; then
+        mkdir -p ~/.ssh
+        ln -sf $SSH_AUTH_SOCK ~/.ssh/ssh_auth_sock
+fi
+
+# unpack personal environment
+if [[ "$USERHOME_DATA" ]] ; then
+        base64 -d <<<"$USERHOME_DATA" | tar -xzC ~
+fi

--- a/configs/supervisord.conf
+++ b/configs/supervisord.conf
@@ -10,14 +10,14 @@ stdout_logfile_maxbytes=0
 
 [program:cron]
 command=/usr/sbin/cron -f -L 15
-stderr_logfile=/var/log/supervisor/cron_error.log
+stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
-stdout_logfile=/var/log/supervisor/cron.log
+stdout_logfile=/dev/stderr
 stdout_logfile_maxbytes=0
 
 [program:c-bastion]
 command=python /usr/local/bin/c-bastiond
-stderr_logfile=/var/log/supervisor/c-bastion_error.log
+stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
-stdout_logfile=/var/log/supervisor/c-bastion.log
+stdout_logfile=/dev/stderr
 stdout_logfile_maxbytes=0

--- a/makefile
+++ b/makefile
@@ -10,7 +10,7 @@ build:
 	docker build -t c-bastion .
 
 run: guard-AUTH_URL
-	docker run -p 127.0.0.1:8080:8080 -e AUTH_URL=${AUTH_URL} c-bastion:latest
+	docker run -p 8080:8080 -p 2222:2222 -e AUTH_URL=${AUTH_URL} c-bastion:latest
 
 # TODO this makes the assumption that there is exactly one container running.
 attach:

--- a/src/unittest/python/index_tests.py
+++ b/src/unittest/python/index_tests.py
@@ -95,7 +95,7 @@ class TestIndex(unittest.TestCase):
             check_and_add('auser')
 
     @patch('sh.id')
-    @patch('sh.userdel')
+    @patch('sh.userdel', create=True)
     @patch('sh.pkill')
     def test_deletion_of_existing_user(self, pkill_mock, userdel_mock, id_mock):
         username = "MPython"


### PR DESCRIPTION
- refactor Docker build environment to have all configs that go into the container in a commen top-level dir
- Export all service logs to Docker stdout (could not see bottle errors)
- Clean up Dockerfile
- Add ssh client
- Add screen with configuration
- Add tmux
- Add python-virtualenv to complete the pip installation into something usable
- Add zsh
