### PR TITLE
autorestart c-bastion ALWAYS

### DIFF
--- a/configs/supervisord.conf
+++ b/configs/supervisord.conf
@@ -17,6 +17,7 @@ stdout_logfile_maxbytes=0
 
 [program:c-bastion]
 command=python /usr/local/bin/c-bastiond
+autorestart=true
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 stdout_logfile=/dev/stderr


### PR DESCRIPTION
This will restart the c-bastion, even if it exits with an exit code of zero.
(This can sometimes happen, when using the gevent backend for bottle.)
